### PR TITLE
Update labelGroupTransformer.js

### DIFF
--- a/src/transformer/labelGroupTransformer.js
+++ b/src/transformer/labelGroupTransformer.js
@@ -1,4 +1,5 @@
-import { COL_LABEL, COL_END, COL_TEXT } from "../common/constants.js";
+import dayjs from "dayjs";
+import { COL_LABEL, COL_START, COL_END, COL_TEXT } from "../common/constants.js";
 /**
  * Groups neighbouring entries with the same label together by merging them.
  * 
@@ -20,7 +21,8 @@ export function transform(input) {
     if (out.length > 0) {
       // if the next time entry has the same label as the last time entry, 
       // we only update the end time, merging the two entries into one
-      if (out[out.length-1][COL_LABEL] === input[i][COL_LABEL]) {
+      // also, we only merge if they are on the same day.
+      if (out[out.length-1][COL_LABEL] === input[i][COL_LABEL] && isSameDay(out[out.length-1], input[i])) {
         console.log('Adding new end time to existing label group');
         out[out.length-1][COL_END] = input[i][COL_END];
         out[out.length-1][COL_TEXT] += ';' + input[i][COL_TEXT]; 
@@ -33,4 +35,10 @@ export function transform(input) {
   }
 
   return out;
+}
+
+function isSameDay(a, b) {
+  let start = dayjs(a[COL_START]);
+  let end = dayjs(b[COL_END]);
+  return start.isSame(end, "day");
 }


### PR DESCRIPTION
the label group transformer undid all actions of the day split transformer, because the entries neighbouring at the day border created by the day split transformer would of course be merged again by the label group transformer, who now checks if the entries are not on the same day.